### PR TITLE
Fix hydrodynamics

### DIFF
--- a/stinger_description/models/stinger_base/components/thrusters.xacro
+++ b/stinger_description/models/stinger_base/components/thrusters.xacro
@@ -17,9 +17,9 @@
 
       <!-- The inertial values need to be reasonable or gazebo will crash -->
       <inertial>
-        <mass value="0.0001" />
-        <inertia ixx="0.01" ixy="0.0" ixz="0.0"
-                 iyy="0.01" iyz="0.0" izz="0.01" />
+        <mass value="0.0000001" />
+        <inertia ixx="0.00001" ixy="0.0" ixz="0.0"
+                 iyy="0.00001" iyz="0.0" izz="0.000001" />
       </inertial>
 
       <visual>

--- a/stinger_description/models/stinger_base/components/thrusters.xacro
+++ b/stinger_description/models/stinger_base/components/thrusters.xacro
@@ -17,7 +17,7 @@
 
       <!-- The inertial values need to be reasonable or gazebo will crash -->
       <inertial>
-        <mass value="0.1" />
+        <mass value="0.0001" />
         <inertia ixx="0.01" ixy="0.0" ixz="0.0"
                  iyy="0.01" iyz="0.0" izz="0.01" />
       </inertial>

--- a/stinger_description/models/stinger_base/stinger_base.xacro
+++ b/stinger_description/models/stinger_base/stinger_base.xacro
@@ -22,72 +22,55 @@
     <!-- port hull -->
     <link name="hull_port_link">
       <collision>
-          <origin xyz="0 0.0765 -0.05" rpy="0 0 0"/>
+          <origin xyz="0.095 0.0 0.0" rpy="0 0 0"/>
           <geometry>
-                <box size="0.381 0.081 0.135" />
+                <box size="0.19 0.081 0.135" />
+          </geometry>
+      </collision>
+      <collision>
+          <origin xyz="-0.095 0.0 0.0" rpy="0 0 0"/>
+          <geometry>
+                <box size="0.19 0.081 0.135" />
           </geometry>
       </collision>
     </link>
     <joint name="hull_port_joint" type="fixed">
-      <origin xyz="0 0 0"/>
+      <origin xyz="0.0 0.0765 -0.035"/>
       <parent link="hull_link"/>
       <child link="hull_port_link"/>
     </joint>
 
     <!-- starboard hull -->
-    <link name="hull_stbd_link">
+    <link name="hull_stbd__link">
       <collision>
-          <origin xyz="0 -0.0765 -0.05" rpy="0 0 0"/>
+          <origin xyz="0.095 0 0" rpy="0 0 0"/>
           <geometry>
-                <box size="0.381 0.081 0.135" />
+            <box size="0.19 0.081 0.135" />
+          </geometry>
+      </collision>
+
+      <collision>
+          <origin xyz="-0.095 0 0" rpy="0 0 0"/>
+          <geometry>
+            <box size="0.19 0.081 0.135" />
           </geometry>
       </collision>
     </link>
-    <joint name="hull_stbd_joint" type="fixed">
-      <origin xyz="0 0 0"/>
+    <joint name="hull_stbd__joint" type="fixed">
+      <origin xyz="0.0 -0.0765 -0.035"/>
       <parent link="hull_link"/>
-      <child link="hull_stbd_link"/>
+      <child link="hull_stbd__link"/>
     </joint>
+
 
     <!-- Thrusters -->
     <xacro:prop_macro thruster_id="port">
       <origin xyz="-0.19 0.073 -0.041" rpy="0 0 0" />
     </xacro:prop_macro>
+
     <xacro:prop_macro thruster_id="stbd">
-      <origin xyz="-0.19 -0.073 -0.041 " rpy="0 0 0" />
+      <origin xyz="-0.19 -0.073 -0.041" rpy="0 0 0" />
     </xacro:prop_macro>
-
-    <!-- Offset weight from propellers to maintain buoyancy -->
-    <!-- TODO: Find a better way to do this -->
-    <link name="box_offset_1">
-      <inertial>
-        <mass value="0.1" />
-        <origin xyz="0.19 0.073 -0.041" />
-        <inertia ixx="0.1" ixy="0.0" ixz="0.0"
-                iyy="0.1" iyz="0.0"
-                izz="0.1" />
-      </inertial>
-    </link>
-    <joint name="offset_joint_1" type="fixed">
-      <origin xyz="0 0 0"/>
-      <parent link="hull_link"/>
-      <child link="box_offset_1"/>
-    </joint>
-
-    <link name="box_offset_2">
-      <inertial>
-        <mass value="0.1" />
-        <origin xyz="0.19 -0.073 -0.041" />
-        <inertia ixx="0.1" ixy="0.0" ixz="0.0"
-                iyy="0.1" iyz="0.0"
-                izz="0.1" />
-      </inertial>
-    </link>
-    <joint name="offset_joint_2" type="fixed">
-      <origin xyz="0 0 0"/>
-      <parent link="hull_link"/>
-      <child link="box_offset_2"/>
-    </joint>
 
     <!-- Sensors -->
     <xacro:camera_macro camera_id="0">
@@ -112,10 +95,6 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
         <link_name> base_link </link_name>
-        <zW>-5.0</zW>
-        <zWabsW>-10.0</zWabsW>
-        <mQ>-50.0</mQ>
-        <mQabsQ>-100.0</mQabsQ>
         
         <!-- Linear Drag -->
         <xU>-5</xU> <!-- Surge -->
@@ -132,8 +111,14 @@
         <mQabsQ>-60</mQabsQ>
         <nRabsR>-50</nRabsR>
       </plugin>
-    </gazebo>
 
+      <!-- Publishes perfect odometry data for ground truth -->
+      <plugin
+        filename="gz-sim-odometry-publisher-system"
+        name="gz::sim::systems::OdometryPublisher">
+        <dimensions>3</dimensions>
+      </plugin>
+    </gazebo>
 
     </xacro:macro>
 </robot>

--- a/stinger_description/models/stinger_base/stinger_base.xacro
+++ b/stinger_description/models/stinger_base/stinger_base.xacro
@@ -41,7 +41,7 @@
     </joint>
 
     <!-- starboard hull -->
-    <link name="hull_stbd__link">
+    <link name="hull_stbd_link">
       <collision>
           <origin xyz="0.095 0 0" rpy="0 0 0"/>
           <geometry>
@@ -56,10 +56,10 @@
           </geometry>
       </collision>
     </link>
-    <joint name="hull_stbd__joint" type="fixed">
+    <joint name="hull_stbd_joint" type="fixed">
       <origin xyz="0.0 -0.0765 -0.035"/>
       <parent link="hull_link"/>
-      <child link="hull_stbd__link"/>
+      <child link="hull_stbd_link"/>
     </joint>
 
 

--- a/stinger_description/models/stinger_base/stinger_base.xacro
+++ b/stinger_description/models/stinger_base/stinger_base.xacro
@@ -8,8 +8,8 @@
     <link name="hull_link">
       <inertial>
         <pose>0.0 0.0 -0.13 0 0 0</pose>
-        <mass value="5"/>
-        <inertia ixx="2.42369" ixy="0" ixz="0" iyy="3.9235025" iyz="0" izz="5.6403125"/>
+        <mass value="3"/>
+        <inertia ixx="1.42369" ixy="0" ixz="0" iyy="2.9235025" iyz="0" izz="3.6403125"/>
       </inertial>
       <visual name="hull_visual">
         <origin rpy="0 0 3.1416"/>
@@ -21,17 +21,22 @@
 
     <!-- port hull -->
     <link name="hull_port_link">
+      <inertial>
+        <mass value="1.0"/>
+        <inertia ixx="0.01" iyy="0.01" izz="0.01"
+                ixy="0.0" ixz="0.0" iyz="0.0"/>
+      </inertial>
       <collision>
-          <origin xyz="0.095 0.0 0.0" rpy="0 0 0"/>
-          <geometry>
-                <box size="0.19 0.081 0.135" />
-          </geometry>
+        <origin xyz="0.095 0.0 0.0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.19 0.081 0.135" />
+        </geometry>
       </collision>
       <collision>
-          <origin xyz="-0.095 0.0 0.0" rpy="0 0 0"/>
-          <geometry>
-                <box size="0.19 0.081 0.135" />
-          </geometry>
+        <origin xyz="-0.095 0.0 0.0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.19 0.081 0.135" />
+        </geometry>
       </collision>
     </link>
     <joint name="hull_port_joint" type="fixed">
@@ -42,17 +47,22 @@
 
     <!-- starboard hull -->
     <link name="hull_stbd_link">
+      <inertial>
+        <mass value="1.0"/>
+        <inertia ixx="0.01" iyy="0.01" izz="0.01"
+                ixy="0.0" ixz="0.0" iyz="0.0"/>
+      </inertial>
       <collision>
-          <origin xyz="0.095 0 0" rpy="0 0 0"/>
-          <geometry>
-            <box size="0.19 0.081 0.135" />
-          </geometry>
+        <origin xyz="0.095 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.19 0.081 0.135" />
+        </geometry>
       </collision>
 
       <collision>
-          <origin xyz="-0.095 0 0" rpy="0 0 0"/>
-          <geometry>
-            <box size="0.19 0.081 0.135" />
+        <origin xyz="-0.095 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.19 0.081 0.135" />
           </geometry>
       </collision>
     </link>

--- a/stinger_sim/config/bridge.yml
+++ b/stinger_sim/config/bridge.yml
@@ -36,3 +36,10 @@
   ros_type_name: "std_msgs/msg/Float64"
   gz_type_name: "gz.msgs.Double"
   direction: ROS_TO_GZ
+
+# Ground truth odometry
+- ros_topic_name: "/ground_truth/odometry"
+  gz_topic_name: "/model/stinger/odometry_with_covariance"
+  ros_type_name: "nav_msgs/msg/Odometry"
+  gz_type_name: "gz.msgs.OdometryWithCovariance"
+  direction: GZ_TO_ROS

--- a/stinger_sim/worlds/empty.world
+++ b/stinger_sim/worlds/empty.world
@@ -1,0 +1,259 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default_world">
+
+    <!-- Configure the scene -->
+    <scene>
+      <!-- For turquoise ambient -->
+      <sky></sky>
+      <grid>true</grid>
+      <ambient>0.0 1 1</ambient>
+      <background>0.0 0.7 0.8</background>
+    </scene>
+
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>33.724223</latitude_deg>
+      <longitude_deg>-84.3880</longitude_deg>
+      <elevation>16.0</elevation>
+      <heading_deg>0.0</heading_deg>
+    </spherical_coordinates>
+
+    <!-- Configure the world physics -->
+    <physics name="1ms" type="dart">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-sensors-system"
+      name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="gz-sim-buoyancy-system"
+      name="gz::sim::systems::Buoyancy">
+      <graded_buoyancy>
+        <default_density>1000</default_density>
+        <density_change>
+          <above_depth>0</above_depth>
+          <density>1</density>
+        </density_change>
+      </graded_buoyancy>
+    </plugin>
+    <plugin filename="gz-sim-imu-system"
+            name="gz::sim::systems::Imu">
+    </plugin>
+    <plugin
+      filename="gz-sim-air-pressure-system"
+      name="gz::sim::systems::AirPressure">
+    </plugin>
+    <plugin
+      filename="gz-sim-navsat-system"
+      name="gz::sim::systems::NavSat">
+    </plugin>
+
+    <!-- Configure the GUI -->
+    <gui>
+      <!-- For some reason this is required to get the GUI to render the scene ambient/background -->
+      <plugin filename="MinimalScene" name="3D View">
+        <gz-gui>
+          <title>3D View</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </gz-gui>
+
+        <engine>ogre2</engine>
+        <scene>scene</scene>
+        <ambient>0.0 1.0 1.0</ambient>
+        <background_color>0.0 0.7 0.8</background_color>
+      </plugin>
+
+      <!-- Plugins that add functionality to the scene (these got removed when using the MinimalScene Plugin so we have to re-add them-->
+      <plugin filename="EntityContextMenuPlugin" name="Entity context menu">
+        <gz-gui>
+          <property key="state" type="string">floating</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+      <plugin filename="GzSceneManager" name="Scene Manager">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+      <plugin filename="InteractiveViewControl" name="Interactive view control">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+      <plugin filename="CameraTracking" name="Camera Tracking">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+
+      <plugin filename="Spawn" name="Spawn Entities">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+
+      <!-- World control -->
+      <plugin filename="WorldControl" name="World control">
+        <gz-gui>
+          <title>World control</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">72</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="left" target="left"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </gz-gui>
+
+        <play_pause>true</play_pause>
+        <step>true</step>
+        <start_paused>true</start_paused>
+        <use_event>true</use_event>
+
+      </plugin>
+
+      <!-- World statistics -->
+      <plugin filename="WorldStats" name="World stats">
+        <gz-gui>
+          <title>World stats</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">110</property>
+          <property type="double" key="width">290</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="right" target="right"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </gz-gui>
+
+        <sim_time>true</sim_time>
+        <real_time>true</real_time>
+        <real_time_factor>true</real_time_factor>
+        <iterations>true</iterations>
+      </plugin>
+
+      <!-- Insert simple shapes -->
+      <plugin filename="Shapes" name="Shapes">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="x" type="double">0</property>
+          <property key="y" type="double">0</property>
+          <property key="width" type="double">250</property>
+          <property key="height" type="double">50</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+          <property key="cardBackground" type="string">#666666</property>
+        </gz-gui>
+      </plugin>
+
+      <!-- Inspector -->
+      <plugin filename="ComponentInspector" name="Component inspector">
+        <gz-gui>
+          <property type="string" key="state">docked</property>
+        </gz-gui>
+      </plugin>
+
+      <!-- Entity tree -->
+      <plugin filename="EntityTree" name="Entity tree">
+        <gz-gui>
+          <property type="string" key="state">docked</property>
+        </gz-gui>
+      </plugin>
+
+      <!-- Translate/Rotate Tools -->
+      <plugin filename="TransformControl" name="Transform control">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="x" type="double">0</property>
+          <property key="y" type="double">50</property>
+          <property key="width" type="double">250</property>
+          <property key="height" type="double">50</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+          <property key="cardBackground" type="string">#777777</property>
+        </gz-gui>
+      </plugin>
+
+    </gui>
+
+
+    <!-- Simulated Water Surface -->
+    <model name="translucent_box">
+      <static>true</static>
+      <pose> 0 0 -2 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>50 50 4</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 1 1 0.5</ambient>
+            <diffuse>1 1 1 0.5</diffuse>
+            <transparency>0.8</transparency>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+
+    <!-- 3D MODELS -->
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>-5 0 10 0 0 0</pose>
+      <diffuse>0.9 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>0.5 0.1 -0.9</direction>
+    </light>
+
+  </world>
+</sdf>


### PR DESCRIPTION
Previously, the center of bouyancys (COB) and center of mass (COM) were defined as the following:
![image](https://github.com/user-attachments/assets/a1db8063-819d-43b0-9cca-d4e055d3c4d4)
base_link: COM
hull_port_link, hull_stbd_link: COB

When running motors with the graded bouyancy plugin, the boat would continuously pitch up. See video below:

[Screencast from 2025-05-22 19-13-52.webm](https://github.com/user-attachments/assets/de1118bb-e568-4f95-9545-0a54395d45b2)

This pitch is due to the thrusters applying a torque on the stinger tug. The graded bouyancy plugin seems to not correctly adjust the location of the center of bouyancy when the stinger tug pitches (the location simply does not change). Since the location does not change, there is no correcting bouyancy force that counteracts the torque from the motors leading to the continuous pitching. 

A suggested solution is to seperate both the port and starboard COB into two collision boxes, as below (only stbd visualized):

![Screenshot from 2025-05-22 19-58-18](https://github.com/user-attachments/assets/8ffb4e14-a94a-4096-a4d4-55ac3ae50f70)

Note, in reality there is only one TF Frame for each pontoon. The above is for visualization only. The real TF looks like the following:

![image](https://github.com/user-attachments/assets/5259ee79-0155-4e27-8fe7-f058623a4d96)

Seperating the COB into two parts  has the effect of creating a correction force for when the stinger pitches (the actual behavior irl). When done so, the stinger becomes much more stable and does not continuously pitch.

[Screencast from 2025-05-22 20-04-50.webm](https://github.com/user-attachments/assets/f55ed81c-6c57-40f8-91ab-cc9a1e6eb4cb)

Wanted to get some feedback if yall think this is good practice/there is a better way to do this.

